### PR TITLE
MOBILE-3320 behat: Trigger change detection once

### DIFF
--- a/tests/behat/behat_app.php
+++ b/tests/behat/behat_app.php
@@ -793,11 +793,8 @@ class behat_app extends behat_base {
             new ExpectationException('Forced cron tasks in the app took too long to complete', $session)
         );
 
-        // Trigger Angular change detection multiple times in case some changes have
-        // side-effects that result in further pending operations.
-        for ($ticks = 5; $ticks > 0; $ticks--) {
-            $session->executeScript($this->islegacy ? 'appRef.tick();' : 'changeDetector.detectChanges();');
-        }
+        // Trigger Angular change detection
+        $session->executeScript($this->islegacy ? 'appRef.tick();' : 'changeDetector.detectChanges();');
     }
 
     /**


### PR DESCRIPTION
Doing it multiple times seems to cause some internal race conditions in Angular that result in flaky tests