### PR TITLE
MOBILE-3833 behat: use ngZone

### DIFF
--- a/tests/behat/behat_app.php
+++ b/tests/behat/behat_app.php
@@ -849,7 +849,7 @@ class behat_app extends behat_base {
         );
 
         // Trigger Angular change detection
-        $session->executeScript($this->islegacy ? 'appRef.tick();' : 'changeDetector.detectChanges();');
+        $session->executeScript($this->islegacy ? 'appRef.tick();' : 'ngZone.run(() => {});');
     }
 
     /**
@@ -862,7 +862,7 @@ class behat_app extends behat_base {
 
         $this->spin(
             function() use ($session) {
-                $session->executeScript($this->islegacy ? 'appRef.tick();' : 'changeDetector.detectChanges();');
+                $session->executeScript($this->islegacy ? 'appRef.tick();' : 'ngZone.run(() => {});');
 
                 $nodes = $this->find_all('css', 'core-loading ion-spinner');
 


### PR DESCRIPTION
Using changeDetector caused some flaky tests throwing errors trying to use undefined variables. ngZone seems to work better.

This PR depends on these changes in the app: https://github.com/moodlehq/moodleapp/pull/2968