### PR TITLE
Missing lang string referenced in classes/privacy/provider.php

### DIFF
--- a/lang/en/local_moodlemobileapp.php
+++ b/lang/en/local_moodlemobileapp.php
@@ -666,6 +666,7 @@ $string['core.youreonline'] = 'You are back online';
 $string['core.zoomin'] = 'Zoom In';
 $string['core.zoomout'] = 'Zoom Out';
 $string['pluginname'] = 'Moodle Mobile language strings';
+$string['privacy_metadata'] = 'This plugin does not store any user data.';
 
 // Deprecated since v3.9.5
 $string['core.whoops'] = 'Oops!';


### PR DESCRIPTION
In the privacy provider it does this:

    public static function get_reason() : string {
        return 'privacy_metadata';
    }

But there is no such string in the lang file. This probably causes errors on some screensin the UI, but also causes a failure if you install this plugin and run core phpunit tests:

core_privacy\privacy\provider_test::test_null_provider with data set "local_moodlemobileapp" ('local_moodlemobileapp', 'local_moodlemobileapp\privacy\provider')
Expectation failed, debugging() was triggered.
Debugging: Invalid get_string() identifier: 'privacy_metadata' or component 'local_moodlemobileapp'. Perhaps you are missing $string['privacy_metadata'] = ''; in /var/www/html/20220525_020000_601_tt_overnight_full/local/moodlemobileapp/lang/en/local_moodlemobileapp.php?